### PR TITLE
Adding customizable noop locker

### DIFF
--- a/lib/ruby_event_store.rb
+++ b/lib/ruby_event_store.rb
@@ -1,3 +1,4 @@
+require 'ruby_event_store/locker'
 require 'ruby_event_store/pub_sub/broker'
 require 'ruby_event_store/in_memory_repository'
 require 'ruby_event_store/projection'

--- a/lib/ruby_event_store/errors.rb
+++ b/lib/ruby_event_store/errors.rb
@@ -5,6 +5,7 @@ module RubyEventStore
   EventNotFound              = Class.new(StandardError)
   SubscriberNotExist         = Class.new(StandardError)
   MethodNotDefined           = Class.new(StandardError)
+  CannotObtainLock           = Class.new(StandardError)
   InvalidPageStart           = Class.new(ArgumentError)
   InvalidPageSize            = Class.new(ArgumentError)
 end

--- a/lib/ruby_event_store/locker.rb
+++ b/lib/ruby_event_store/locker.rb
@@ -1,0 +1,7 @@
+module RubyEventStore
+  class Locker
+    def with_lock(*)
+      yield
+    end
+  end
+end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -15,6 +15,14 @@ module RubyEventStore
       expect(client.append_to_stream(TestEvent.new, stream_name: stream)).to eq(:ok)
     end
 
+    specify 'append_to_stream uses a locker' do
+      locker = double(:locker)
+      stream = SecureRandom.uuid
+      client = RubyEventStore::Client.new(repository: InMemoryRepository.new, locker: locker)
+      expect(locker).to receive(:with_lock).with(stream).and_yield
+      expect(client.append_to_stream(TestEvent.new, stream_name: stream)).to eq(:ok)
+    end
+
     specify 'append to default stream when not specified' do
       client = RubyEventStore::Client.new(repository: InMemoryRepository.new)
       test_event = TestEvent.new

--- a/spec/locker_spec.rb
+++ b/spec/locker_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+module RubyEventStore
+  describe Locker do
+    specify { expect { |b| subject.with_lock('stream', &b) }.to yield_control }
+    specify { expect { |b| subject.with_lock(&b) }.to yield_control }
+  end
+end


### PR DESCRIPTION
Overview

This changes allow to perform a database lock per aggregates in order to avoid concurrency issues in a concurrent environment, such as, multi-threaded env or load balanced event store (multiple event store processes trying to create events on the database at the same time).

The lock only blocks the aggregate, not the entire event table. A RubyEventStore::CannotObtainLock exception is raised in case the lock could not be obtained. Meaning an event store was already trying to perform an INSERT on the given aggregate.

From a client perspective, a good place to catch this exception is when loading the events in the aggregate:

```ruby
module CommandHandlers
  class Base
    def with_aggregate(aggregate_id, aggregate_class:)
      aggregate = build(aggregate_id, aggregate_class)
      yield aggregate
      aggregate.store(aggregate_id, event_store: event_store)
    rescue ::RubyEventStore::CannotObtainLock
      retry
    end

    def build(aggregate_id, aggregate_class)
      aggregate_class.new(aggregate_id).tap do |aggregate|
        aggregate.load(aggregate_id, event_store: event_store)
      end
    end
  end
end
```

This way a client can ensure latest events are loaded in the aggregate.