### PR TITLE
Allows unique subscribers per event type

### DIFF
--- a/lib/ruby_event_store/pub_sub/broker.rb
+++ b/lib/ruby_event_store/pub_sub/broker.rb
@@ -23,7 +23,7 @@ module RubyEventStore
       DEFAULT_DISPATCHER = Dispatcher.new
 
       def initialize(dispatcher: DEFAULT_DISPATCHER)
-        @subscribers = Hash.new {|hsh, key| hsh[key] = [] }
+        @subscribers = Hash.new {|hsh, key| hsh[key] = Set.new }
         @global_subscribers = []
         @dispatcher = dispatcher
       end

--- a/lib/ruby_event_store/spec/event_broker_lint.rb
+++ b/lib/ruby_event_store/spec/event_broker_lint.rb
@@ -42,6 +42,7 @@ RSpec.shared_examples :event_broker do |broker_class|
 
     broker.add_subscriber(handler, [Test1DomainEvent, Test3DomainEvent])
     broker.add_subscriber(another_handler, [Test2DomainEvent])
+    broker.add_subscriber(another_handler, [Test2DomainEvent])
     broker.add_global_subscriber(global_handler)
 
     event1 = Test1DomainEvent.new


### PR DESCRIPTION
In highly concurrent setup we could run into issues where we add
multiple time a subscriber to the same event(s).
Using a `Set` instead of an array will ensure unique subscribers
per event type.